### PR TITLE
Allow 7d queries for traceQL metrics. (Default was 3h)

### DIFF
--- a/docker-compose/tempo/config.yaml
+++ b/docker-compose/tempo/config.yaml
@@ -9,6 +9,8 @@ query_frontend:
     throughput_bytes_slo: 1.073741824e+09
   trace_by_id:
     duration_slo: 5s
+  metrics:
+    max_duration: 168h
 
 distributor:
   log_received_spans:


### PR DESCRIPTION
<img width="1895" alt="image" src="https://github.com/mladenrtl/otel-drupal-demo/assets/2423149/21efc0df-38f2-4125-b57b-d9d4b3039354">
