### PR TITLE
Add grafana dashboard for opentelemetry apps red

### DIFF
--- a/docker-compose/grafana/dashboards/opentelemetry_apps_red.json
+++ b/docker-compose/grafana/dashboards/opentelemetry_apps_red.json
@@ -208,6 +208,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx Errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
<img width="1715" alt="image" src="https://github.com/mladenrtl/otel-drupal-demo/assets/2423149/64822cee-786f-4349-91bf-8ee6839e78a0">
